### PR TITLE
Fix: Background image not changing and service worker error

### DIFF
--- a/script.js
+++ b/script.js
@@ -26,7 +26,7 @@ function loadBackgroundImage() {
         if (initialAttemptWasWithDynamicDimensions) {
             console.warn(`Initial attempt with dynamic dimensions (${width}x${height}) failed. Trying fallback 800x600. URL: ${img.src}`);
             initialAttemptWasWithDynamicDimensions = false; // Prevent retry loop
-                img.src = 'https://picsum.photos/800/600'; // Fallback
+                img.src = 'https://picsum.photos/800/600?timestamp=' + new Date().getTime(); // Fallback
         } else {
             console.error(`Error loading background image from Unsplash. Also failed with fallback or fallback was initial. URL: ${img.src}`);
             if (imageArea) {
@@ -39,10 +39,10 @@ function loadBackgroundImage() {
     const height = imageArea.offsetHeight;
     if (width && height && !isNaN(width) && !isNaN(height) && width > 0 && height > 0) {
         initialAttemptWasWithDynamicDimensions = true;
-        img.src = `https://picsum.photos/${width}/${height}`;
+        img.src = `https://picsum.photos/${width}/${height}?timestamp=${new Date().getTime()}`;
     } else {
         initialAttemptWasWithDynamicDimensions = false; // Ensure it's false if we go directly to fallback
-        img.src = 'https://picsum.photos/800/600'; // Fallback
+        img.src = 'https://picsum.photos/800/600?timestamp=' + new Date().getTime(); // Fallback
     }
 }
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -6,7 +6,6 @@ const urlsToCache = [
   'script.js',
   // Add paths to any local icons if you have them, e.g., 'icons/icon-192x192.png'
   // For now, we'll assume icons are served or this list can be expanded later.
-  'https://fonts.gstatic.com/s/lato/v16/S6uyw4BMUTPHjx4wWw.woff2' // Example of caching a Google Font if used
 ];
 
 // Install event: Cache essential assets


### PR DESCRIPTION
- I modified script.js to add a cache-busting timestamp to Picsum image URLs. This ensures that a new background image is fetched every 3 word sets, preventing browser caching of the same image URL.
- I fixed a TypeError in service-worker.js during installation by removing an external Google Font URL from the urlsToCache list. This allows the service worker to install and function correctly, ensuring reliable caching of app assets and proper application of its fetching rules.

You confirmed that background images now change correctly on all devices and the service worker error is resolved.