### PR TITLE
Add GitHub Action for GitHub Pages deployment

### DIFF
--- a/.github/workflows/.gitkeep
+++ b/.github/workflows/.gitkeep
@@ -1,0 +1,2 @@
+# This file is used to ensure that Git tracks the .github/workflows directory.
+# It can be removed once actual workflow files are added.

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,33 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main # Or your default branch
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup GitHub Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./www
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow to automate the deployment of the 'www' folder to GitHub Pages.

The workflow is triggered on pushes to the main branch and includes the following steps:
- Checkout the repository
- Configure GitHub Pages
- Upload the 'www' folder as an artifact
- Deploy the artifact to GitHub Pages